### PR TITLE
refactor: move container global styles to styles.css

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -26,22 +26,3 @@
   grid-area: main;
   background-color: rebeccapurple;
 }
-
-/* rux-container styles */
-rux-container {
-  height: 100%;
-}
-
-rux-container::part(container) {
-  display: flex;
-  flex-direction: column;
-  height: calc(100% - 2px);
-  overflow-y: hidden;
-}
-
-rux-container::part(body) {
-  flex-grow: 1;
-  display: flex;
-  flex-direction: column;
-  overflow-y: hidden;
-}

--- a/src/app/scenario-library/scenario-library.component.ts
+++ b/src/app/scenario-library/scenario-library.component.ts
@@ -5,7 +5,7 @@ import { AstroComponentsModule, RuxToastStack } from '@astrouxds/angular';
   standalone: true,
   selector: 'fds-scenario-library',
   templateUrl: './scenario-library.component.html',
-  styleUrls: ['./scenario-library.component.css', '../app.component.css'],
+  styleUrls: ['./scenario-library.component.css'],
   imports: [AstroComponentsModule, CommonModule],
 })
 export class ScenarioLibraryComponent {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,20 @@
 @import "@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css";
+
+/* rux-container styles */
+rux-container {
+  height: 100%;
+}
+
+rux-container::part(container) {
+  display: flex;
+  flex-direction: column;
+  height: calc(100% - 2px);
+  overflow-y: hidden;
+}
+
+rux-container::part(body) {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  overflow-y: hidden;
+}


### PR DESCRIPTION


## Brief Description
In the [Scenarios Library PR](https://github.com/RocketCommunicationsInc/Flight-Dynamics-Service/pull/7) I added global `rux-container` styles, but didn't add them to the right file. 
This change moves those styles from `app.component.css` to the highest level of `styles.css`. 

<!-- Reference coding changes rather than just the elements of the task (one-liner), what do you want to call out to the reviewer?  -->
<!-- It is also good practice to put your own comments in the file view to easily identify locations in the code you believe need explination -->

## Issues and/or Limitations

<!-- Use to explain scenarios that may require another ticket, or difficult scenarios in general -->

## Final Checklist

- [ ] Works in Chrome
- [ ] Works in Firefox
- [ ] Works in Safari
- [ ] Handles responsiveness as required
- [ ] Dark theme styles are correct
- [ ] Light theme styles are correct
