### PR TITLE
DEMO-323 (feature): Add global status bar

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -45,3 +45,8 @@ rux-container::part(body) {
   flex-direction: column;
   overflow-y: hidden;
 }
+
+/* Move toast stack down below gsb */
+rux-toast-stack {
+  top: 6rem;
+}

--- a/src/app/global-status-bar/global-status-bar.component.css
+++ b/src/app/global-status-bar/global-status-bar.component.css
@@ -1,3 +1,7 @@
+rux-global-status-bar rux-pop-up {
+  height: calc(var(--spacing-14) + var(--spacing-050));
+}
+
 rux-global-status-bar::part(middle) {
   align-self: stretch;
   flex-grow: 1;

--- a/src/app/global-status-bar/global-status-bar.component.css
+++ b/src/app/global-status-bar/global-status-bar.component.css
@@ -1,0 +1,33 @@
+rux-global-status-bar::part(middle) {
+  align-self: stretch;
+  flex-grow: 1;
+}
+
+.gsb-tools {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-grow: 1;
+  gap: var(--spacing-2);
+
+  & rux-tabs {
+    height: auto;
+    align-self: flex-end;
+  }
+
+  & .gsb-icons {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--spacing-2);
+
+    & rux-monitoring-icon::part(status-icon) {
+      display: none;
+    }
+
+    & *::part(icon) {
+      color: var(--color-text-interactive-default);
+      cursor: pointer;
+    }
+  }
+}

--- a/src/app/global-status-bar/global-status-bar.component.html
+++ b/src/app/global-status-bar/global-status-bar.component.html
@@ -16,7 +16,9 @@
       <rux-menu-item value="unavailable">App 2</rux-menu-item>
       <rux-menu-item value="unavailable">App 3</rux-menu-item>
       <rux-menu-item-divider></rux-menu-item-divider>
-      <rux-menu-item value="mode">{{ this }} Mode</rux-menu-item>
+      <rux-menu-item value="mode"
+        >{{ this.lightMode ? "Dark" : "Light" }} Mode</rux-menu-item
+      >
       <rux-menu-item value="unavailable">Preferences</rux-menu-item>
       <rux-menu-item value="unavailable">Sign Out</rux-menu-item>
     </rux-menu>

--- a/src/app/global-status-bar/global-status-bar.component.html
+++ b/src/app/global-status-bar/global-status-bar.component.html
@@ -11,7 +11,7 @@
     slot="left-side"
   >
     <rux-icon icon="apps" slot="trigger" size="2rem"></rux-icon>
-    <rux-menu>
+    <rux-menu (ruxmenuselected)="handleSelection($event)">
       <rux-menu-item href="#">Flight Dynamic Service</rux-menu-item>
       <rux-menu-item value="unavailable">App 2</rux-menu-item>
       <rux-menu-item value="unavailable">App 3</rux-menu-item>

--- a/src/app/global-status-bar/global-status-bar.component.html
+++ b/src/app/global-status-bar/global-status-bar.component.html
@@ -1,1 +1,45 @@
-<p>global-status-bar works!</p>
+<rux-global-status-bar
+  app-state="Demo"
+  app-domain="FDS"
+  app-name="DSCS"
+  username="J. Smith"
+>
+  <rux-pop-up
+    placement="bottom-start"
+    disable-auto-update
+    close-on-select
+    slot="left-side"
+  >
+    <rux-icon icon="apps" slot="trigger" size="2rem"></rux-icon>
+    <rux-menu>
+      <rux-menu-item href="#">Flight Dynamic Service</rux-menu-item>
+      <rux-menu-item value="unavailable">App 2</rux-menu-item>
+      <rux-menu-item value="unavailable">App 3</rux-menu-item>
+      <rux-menu-item-divider></rux-menu-item-divider>
+      <rux-menu-item value="mode">{{ this }} Mode</rux-menu-item>
+      <rux-menu-item value="unavailable">Preferences</rux-menu-item>
+      <rux-menu-item value="unavailable">Sign Out</rux-menu-item>
+    </rux-menu>
+  </rux-pop-up>
+  <div class="gsb-tools">
+    <rux-tabs id="workspaces">
+      <rux-tab id="workspace-1" selected>Orbit Determination</rux-tab>
+      <rux-tab id="workspace-2" disabled>Maneuvering</rux-tab>
+      <rux-tab id="workspace-3" disabled>Reporting</rux-tab>
+    </rux-tabs>
+    <rux-clock date-in></rux-clock>
+    <div class="gsb-icons" slot="right-side">
+      <rux-monitoring-icon
+        icon="notifications"
+        status="off"
+        notifications="1"
+      ></rux-monitoring-icon>
+      <rux-monitoring-icon
+        icon="message"
+        status="off"
+        notifications="1"
+      ></rux-monitoring-icon>
+      <rux-icon icon="account-circle"></rux-icon>
+    </div>
+  </div>
+</rux-global-status-bar>

--- a/src/app/global-status-bar/global-status-bar.component.html
+++ b/src/app/global-status-bar/global-status-bar.component.html
@@ -32,6 +32,7 @@
     <rux-clock date-in></rux-clock>
     <div class="gsb-icons" slot="right-side">
       <rux-monitoring-icon
+        (click)="showToast()"
         icon="notifications"
         status="off"
         notifications="1"
@@ -40,8 +41,9 @@
         icon="message"
         status="off"
         notifications="1"
+        (click)="showToast()"
       ></rux-monitoring-icon>
-      <rux-icon icon="account-circle"></rux-icon>
+      <rux-icon (click)="showToast()" icon="account-circle"></rux-icon>
     </div>
   </div>
 </rux-global-status-bar>

--- a/src/app/global-status-bar/global-status-bar.component.ts
+++ b/src/app/global-status-bar/global-status-bar.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { AstroComponentsModule} from '@astrouxds/angular';
+import { AstroComponentsModule, RuxToastStack} from '@astrouxds/angular';
 
 @Component({
   standalone: true,
@@ -9,7 +9,24 @@ import { AstroComponentsModule} from '@astrouxds/angular';
   imports: [AstroComponentsModule],
 })
 export class GlobalStatusBarComponent {
+
+  lightMode: Boolean;
+
   handleSelection(e: Event){
     const event = e as CustomEvent
+    if(event.detail.value === 'mode'){
+      const body = document.body;
+      if(body){
+        body.classList.toggle('light-theme')
+      }
+      this.lightMode = !this.lightMode
+    }
+    if(event.detail.value === 'unavailable'){
+      console.log('toast goes here')
+    }
+  }
+
+  constructor(){
+    this.lightMode = false
   }
 }

--- a/src/app/global-status-bar/global-status-bar.component.ts
+++ b/src/app/global-status-bar/global-status-bar.component.ts
@@ -1,9 +1,11 @@
 import { Component } from '@angular/core';
+import { AstroComponentsModule } from '@astrouxds/angular';
 
 @Component({
   standalone: true,
   selector: 'app-global-status-bar',
   templateUrl: './global-status-bar.component.html',
   styleUrls: ['./global-status-bar.component.css'],
+  imports: [AstroComponentsModule],
 })
 export class GlobalStatusBarComponent {}

--- a/src/app/global-status-bar/global-status-bar.component.ts
+++ b/src/app/global-status-bar/global-status-bar.component.ts
@@ -12,6 +12,8 @@ export class GlobalStatusBarComponent {
 
   lightMode: Boolean;
 
+
+
   handleSelection(e: Event){
     const event = e as CustomEvent
     if(event.detail.value === 'mode'){
@@ -22,11 +24,26 @@ export class GlobalStatusBarComponent {
       this.lightMode = !this.lightMode
     }
     if(event.detail.value === 'unavailable'){
-      console.log('toast goes here')
+      this.showToast()
+    }
+  }
+  /**
+   * Show the 'feature not implemented' toast.
+   */
+  showToast() {
+    console.log('running!')
+    const toastStack = document.querySelector('rux-toast-stack')
+    if (toastStack) {
+      toastStack.addToast({
+        message: 'This feature has not been implemented.',
+        hideClose: false,
+        closeAfter: 3000,
+      });
     }
   }
 
   constructor(){
     this.lightMode = false
+    this.showToast()
   }
 }

--- a/src/app/global-status-bar/global-status-bar.component.ts
+++ b/src/app/global-status-bar/global-status-bar.component.ts
@@ -9,18 +9,13 @@ import { AstroComponentsModule, RuxToastStack} from '@astrouxds/angular';
   imports: [AstroComponentsModule],
 })
 export class GlobalStatusBarComponent {
-
   lightMode: Boolean;
-
-
 
   handleSelection(e: Event){
     const event = e as CustomEvent
     if(event.detail.value === 'mode'){
       const body = document.body;
-      if(body){
-        body.classList.toggle('light-theme')
-      }
+      body?.classList.toggle('light-theme')
       this.lightMode = !this.lightMode
     }
     if(event.detail.value === 'unavailable'){
@@ -31,15 +26,13 @@ export class GlobalStatusBarComponent {
    * Show the 'feature not implemented' toast.
    */
   showToast() {
-    console.log('running!')
+    /* Scenario Library is currently housing RuxToastStack */
     const toastStack = document.querySelector('rux-toast-stack')
-    if (toastStack) {
-      toastStack.addToast({
-        message: 'This feature has not been implemented.',
-        hideClose: false,
-        closeAfter: 3000,
-      });
-    }
+    toastStack?.addToast({
+      message: 'This feature has not been implemented.',
+      hideClose: false,
+      closeAfter: 3000,
+    });
   }
 
   constructor(){

--- a/src/app/global-status-bar/global-status-bar.component.ts
+++ b/src/app/global-status-bar/global-status-bar.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { AstroComponentsModule } from '@astrouxds/angular';
+import { AstroComponentsModule} from '@astrouxds/angular';
 
 @Component({
   standalone: true,
@@ -8,4 +8,8 @@ import { AstroComponentsModule } from '@astrouxds/angular';
   styleUrls: ['./global-status-bar.component.css'],
   imports: [AstroComponentsModule],
 })
-export class GlobalStatusBarComponent {}
+export class GlobalStatusBarComponent {
+  handleSelection(e: Event){
+    const event = e as CustomEvent
+  }
+}


### PR DESCRIPTION
**JIRA Ticket [Jira Issue Key](ticketURL)**

[DEMO-323](https://rocketcom.atlassian.net/browse/DEMO-323)

## Brief Description

Created the global status bar with all elements currently present in the wireframes and slotted it into the GSB slot in the layout.

Additional features:

- pop up menu with toasts on unimplemented menu items
- light/dark mode toggle
- icons on the right-hand side also utilize the toasts for unimplemented features

## Issues and/or Limitations

We will likely need to come back to the GSB for polish, but a couple items of note I was unsure about:

- The <rux-toast-stack /> is implemented in the Scenario Library component. I wasn't sure how to get at it, but did not want to refactor another component in this PR. So I'm just doing a querySelector to find it for my function. Not sure if this is the best way.
- Similarly, not sure if there is a more accepted way to get the document body to add `light-theme` class, so I'm just grabbing document.body when I need it.
- Not sure what the icons will do or if we'll even use them. I added click events to them but honestly if we do end up using them we should toss a button around them or at least give them a tab index and proper aria role.

## Final Checklist

- [x] Works in Chrome
- [x] Works in Firefox
- [x] Works in Safari
- [x] Handles responsiveness as required 
- [x] Dark theme styles are correct
- [x] Light theme styles are correct - and now we can check them!
