### PR TITLE
fix: have app root target body element

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,7 +10,7 @@ import { BehaviorSubject, Subject, filter, takeUntil, tap } from 'rxjs';
 
 @Component({
   standalone: true,
-  selector: 'fds-root',
+  selector: 'body',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],
   imports: [


### PR DESCRIPTION


## Brief Description

This is a small refactor for Jacob's lightTheme refactor (of my refactor etc). We figured out how to get the main component to target `<body>` so that we can apply light-theme there when switching modes

## Issues and/or Limitations

<!-- Use to explain scenarios that may require another ticket, or difficult scenarios in general -->

## Final Checklist

- [x] Works in Chrome
- [x] Works in Firefox
- [x] Works in Safari
- [x] Handles responsiveness as required
- [x] Dark theme styles are correct
- [x] Light theme styles are correct
