### PR TITLE
DEMO-376 (feature): Creates propagator utility scaffolding

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true
+}

--- a/src/app/main/inputs-outputs-data-display/inputs-outputs-data-display.component.css
+++ b/src/app/main/inputs-outputs-data-display/inputs-outputs-data-display.component.css
@@ -3,4 +3,5 @@
   gap: var(--spacing-4);
   flex-grow: 1;
   height: 100%;
+  padding-inline: var(--spacing-4);
 }

--- a/src/app/main/main.component.css
+++ b/src/app/main/main.component.css
@@ -5,4 +5,5 @@ main {
 
 rux-container::part(body) {
   padding-block-start: var(--spacing-0);
+  padding-inline: 0px;
 }

--- a/src/app/main/utility-components/propagator-utility/input-source/input-source.component.css
+++ b/src/app/main/utility-components/propagator-utility/input-source/input-source.component.css
@@ -1,0 +1,3 @@
+rux-container::part(container) {
+  border: none;
+}

--- a/src/app/main/utility-components/propagator-utility/input-source/input-source.component.html
+++ b/src/app/main/utility-components/propagator-utility/input-source/input-source.component.html
@@ -1,1 +1,45 @@
-<p>input-source works!</p>
+<rux-container>
+  <div class="toolbar">
+    Toolbar
+    <!-- <rux-button>Controls</rux-button> -->
+  </div>
+
+  <form>
+    Form
+    <!-- <section class="form-section">
+      <h3>Source Settings</h3>
+
+      <rux-select label="Orbit Source">
+        <rux-option label="Ephemeris" />
+        <rux-option label="TLE" />
+      </rux-select>
+      <rux-input placeholder="eph_020120.ephm" />
+    </section>
+
+    <section class="form-section">
+      <h3>Epoch Settings</h3>
+
+      <rux-select label="Orbit Source">
+        <rux-option label="Ephemeris" />
+        <rux-option label="TLE" />
+      </rux-select>
+      <rux-input placeholder="eph_020120.ephm" />
+    </section>
+
+    <section class="form-section">
+      <h3>Date & Duration</h3>
+
+      <rux-select label="Orbit Source">
+        <rux-option label="Ephemeris" />
+        <rux-option label="TLE" />
+      </rux-select>
+      <rux-input placeholder="eph_020120.ephm" />
+    </section> -->
+  </form>
+  <aside class="controls">Controls</aside>
+
+  <div class="footer">
+    <!-- <rux-button>Secondary Action</rux-button>
+    <rux-button>Primary Action</rux-button> -->
+  </div>
+</rux-container>

--- a/src/app/main/utility-components/propagator-utility/input-source/input-source.component.html
+++ b/src/app/main/utility-components/propagator-utility/input-source/input-source.component.html
@@ -1,0 +1,1 @@
+<p>input-source works!</p>

--- a/src/app/main/utility-components/propagator-utility/input-source/input-source.component.spec.ts
+++ b/src/app/main/utility-components/propagator-utility/input-source/input-source.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { InputSourceComponent } from './input-source.component';
+
+describe('InputSourceComponent', () => {
+  let component: InputSourceComponent;
+  let fixture: ComponentFixture<InputSourceComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [InputSourceComponent]
+    });
+    fixture = TestBed.createComponent(InputSourceComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/main/utility-components/propagator-utility/input-source/input-source.component.ts
+++ b/src/app/main/utility-components/propagator-utility/input-source/input-source.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'fds-input-source',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './input-source.component.html',
+  styleUrls: ['./input-source.component.css']
+})
+export class InputSourceComponent {
+
+}

--- a/src/app/main/utility-components/propagator-utility/input-source/input-source.component.ts
+++ b/src/app/main/utility-components/propagator-utility/input-source/input-source.component.ts
@@ -1,10 +1,10 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-
+import { AstroComponentsModule } from '@astrouxds/angular';
 @Component({
   selector: 'fds-input-source',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, AstroComponentsModule],
   templateUrl: './input-source.component.html',
   styleUrls: ['./input-source.component.css']
 })

--- a/src/app/main/utility-components/propagator-utility/propagator-utility.component.css
+++ b/src/app/main/utility-components/propagator-utility/propagator-utility.component.css
@@ -1,0 +1,12 @@
+rux-container::part(container) {
+  border: none;
+}
+
+header {
+  display: flex;
+  gap: 0.5rem;
+}
+
+header button {
+  margin-inline-start: auto;
+}

--- a/src/app/main/utility-components/propagator-utility/propagator-utility.component.html
+++ b/src/app/main/utility-components/propagator-utility/propagator-utility.component.html
@@ -1,1 +1,20 @@
-<p>propagator-utility works!</p>
+<rux-container>
+  <div slot="header">
+    <rux-icon icon="public" size="small" />Propagator Utility
+    <button (click)="navigateBack()">Back</button>
+  </div>
+
+  <rux-tabs id="propagator-tabs">
+    <rux-tab id="input-source" small selected="true">Input Source</rux-tab>
+    <rux-tab id="view-orbit" small>View Orbit</rux-tab>
+  </rux-tabs>
+
+  <rux-tab-panels aria-labelledby="propagator-tabs">
+    <rux-tab-panel aria-labelledby="input-source">
+        Input source content
+    </rux-tab-panel>
+    <rux-tab-panel aria-labelledby="view-orbit">
+        View orbit content
+    </rux-tab-panel>
+</rux-tab-panels>
+</rux-container>

--- a/src/app/main/utility-components/propagator-utility/propagator-utility.component.html
+++ b/src/app/main/utility-components/propagator-utility/propagator-utility.component.html
@@ -1,20 +1,20 @@
-<rux-container>
-  <div slot="header">
+<rux-container class="utility">
+  <header slot="header">
     <rux-icon icon="public" size="small" />Propagator Utility
     <button (click)="navigateBack()">Back</button>
-  </div>
+  </header>
 
-  <rux-tabs id="propagator-tabs">
+  <rux-tabs id="propagator-tabs" slot="tab-bar">
     <rux-tab id="input-source" small selected="true">Input Source</rux-tab>
     <rux-tab id="view-orbit" small>View Orbit</rux-tab>
   </rux-tabs>
 
   <rux-tab-panels aria-labelledby="propagator-tabs">
     <rux-tab-panel aria-labelledby="input-source">
-        Input source content
+      <fds-input-source></fds-input-source>
     </rux-tab-panel>
     <rux-tab-panel aria-labelledby="view-orbit">
-        View orbit content
+      <fds-view-orbit></fds-view-orbit>
     </rux-tab-panel>
-</rux-tab-panels>
+  </rux-tab-panels>
 </rux-container>

--- a/src/app/main/utility-components/propagator-utility/propagator-utility.component.ts
+++ b/src/app/main/utility-components/propagator-utility/propagator-utility.component.ts
@@ -2,11 +2,13 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AstroComponentsModule } from '@astrouxds/angular';
 import { Router, RouterLink, RouterOutlet } from '@angular/router';
+import { InputSourceComponent } from "./input-source/input-source.component"
+import { ViewOrbitComponent } from './view-orbit/view-orbit.component';
 
 @Component({
   selector: 'fds-propagator-util',
   standalone: true,
-  imports: [AstroComponentsModule, RouterLink, RouterOutlet, CommonModule],
+  imports: [AstroComponentsModule, RouterLink, RouterOutlet, CommonModule, InputSourceComponent, ViewOrbitComponent],
   templateUrl: './propagator-utility.component.html',
   styleUrls: ['./propagator-utility.component.css'],
 })

--- a/src/app/main/utility-components/propagator-utility/propagator-utility.component.ts
+++ b/src/app/main/utility-components/propagator-utility/propagator-utility.component.ts
@@ -1,11 +1,20 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { AstroComponentsModule } from '@astrouxds/angular';
+import { Router, RouterLink, RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'fds-propagator-util',
   standalone: true,
-  imports: [CommonModule],
+  imports: [AstroComponentsModule, RouterLink, RouterOutlet, CommonModule],
   templateUrl: './propagator-utility.component.html',
   styleUrls: ['./propagator-utility.component.css'],
 })
-export class PropagatorUtilityComponent {}
+export class PropagatorUtilityComponent {
+  constructor(private router: Router) { }
+  
+  navigateBack() {
+    this.router.navigateByUrl('/')
+  }
+
+}

--- a/src/app/main/utility-components/propagator-utility/view-orbit/view-orbit.component.css
+++ b/src/app/main/utility-components/propagator-utility/view-orbit/view-orbit.component.css
@@ -1,0 +1,3 @@
+rux-container::part(container) {
+  border: none;
+}

--- a/src/app/main/utility-components/propagator-utility/view-orbit/view-orbit.component.html
+++ b/src/app/main/utility-components/propagator-utility/view-orbit/view-orbit.component.html
@@ -1,0 +1,1 @@
+<p>view-orbit works!</p>

--- a/src/app/main/utility-components/propagator-utility/view-orbit/view-orbit.component.html
+++ b/src/app/main/utility-components/propagator-utility/view-orbit/view-orbit.component.html
@@ -1,1 +1,12 @@
-<p>view-orbit works!</p>
+<rux-container>
+  <div class="toolbar">Toolbar</div>
+
+  <section>
+    <div>Visualization Controls</div>
+    <div>Visualization</div>
+  </section>
+
+  <aside class="controls">Controls</aside>
+
+  <div class="footer">Playback controls</div>
+</rux-container>

--- a/src/app/main/utility-components/propagator-utility/view-orbit/view-orbit.component.spec.ts
+++ b/src/app/main/utility-components/propagator-utility/view-orbit/view-orbit.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ViewOrbitComponent } from './view-orbit.component';
+
+describe('ViewOrbitComponent', () => {
+  let component: ViewOrbitComponent;
+  let fixture: ComponentFixture<ViewOrbitComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ViewOrbitComponent]
+    });
+    fixture = TestBed.createComponent(ViewOrbitComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/main/utility-components/propagator-utility/view-orbit/view-orbit.component.ts
+++ b/src/app/main/utility-components/propagator-utility/view-orbit/view-orbit.component.ts
@@ -1,13 +1,11 @@
-import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
-
+import { Component } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { AstroComponentsModule } from '@astrouxds/angular'
 @Component({
   selector: 'fds-view-orbit',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, AstroComponentsModule],
   templateUrl: './view-orbit.component.html',
-  styleUrls: ['./view-orbit.component.css']
+  styleUrls: ['./view-orbit.component.css'],
 })
-export class ViewOrbitComponent {
-
-}
+export class ViewOrbitComponent {}

--- a/src/app/main/utility-components/propagator-utility/view-orbit/view-orbit.component.ts
+++ b/src/app/main/utility-components/propagator-utility/view-orbit/view-orbit.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'fds-view-orbit',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './view-orbit.component.html',
+  styleUrls: ['./view-orbit.component.css']
+})
+export class ViewOrbitComponent {
+
+}


### PR DESCRIPTION
**JIRA Ticket [DEMO-376](https://rocketcom.atlassian.net/browse/DEMO-376)**

## Brief Description

This is the first PR in the ticket to create the Propagator Utility screen. It builds the scaffodling for the tab views and header.

This PR also adjusts where padding is held so the main dashboard will continue to have padding while sub-containers in the propagator will not have padding to keep alignment the same in all views. 

## Issues and/or Limitations

Un-styled back button left in for convenience while developing feature

## Final Checklist

- [X] Works in Chrome
- [X] Works in Firefox
- [X] Works in Safari
- [X] Handles responsiveness as required
- [X] Dark theme styles are correct
- [X] Light theme styles are correct
