### PR TITLE
DEMO-371 (refactor):  tabbed-child-container-component

### DIFF
--- a/src/app/main/inputs-outputs/inputs-outputs.component.html
+++ b/src/app/main/inputs-outputs/inputs-outputs.component.html
@@ -1,18 +1,16 @@
 <fds-tabbed-child-container
   [tabs]="tabs"
+  [hasTabPanels]="true"
   [tabsParentId]="tabsId"
   [notificationData]="notificationData"
   [notificationHideClose]="false"
 >
-  <!--
-    <fds-inputs inputs></fds-inputs>
-    <fds-outputs outputs></fds-outputs> -->
-  <rux-tab-panels [attr.aria-labelledby]="tabsId">
+  <ng-container panels>
     <rux-tab-panel aria-labelledby="inputs-tab">
       <fds-inputs></fds-inputs>
     </rux-tab-panel>
     <rux-tab-panel aria-labelledby="outputs-tab">
       <fds-outputs></fds-outputs>
     </rux-tab-panel>
-  </rux-tab-panels>
+  </ng-container>
 </fds-tabbed-child-container>

--- a/src/app/main/inputs-outputs/inputs/inputs.component.ts
+++ b/src/app/main/inputs-outputs/inputs/inputs.component.ts
@@ -1,12 +1,17 @@
 import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { CommonModule, NgTemplateOutlet } from '@angular/common';
 import { AstroComponentsModule } from '@astrouxds/angular';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 
 @Component({
   selector: 'fds-inputs',
   standalone: true,
-  imports: [CommonModule, AstroComponentsModule, ReactiveFormsModule],
+  imports: [
+    CommonModule,
+    AstroComponentsModule,
+    ReactiveFormsModule,
+    NgTemplateOutlet,
+  ],
   templateUrl: './inputs.component.html',
   styleUrls: ['./inputs.component.css'],
 })

--- a/src/app/main/inputs-outputs/outputs/outputs.component.ts
+++ b/src/app/main/inputs-outputs/outputs/outputs.component.ts
@@ -1,12 +1,17 @@
 import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { CommonModule, NgTemplateOutlet } from '@angular/common';
 import { AstroComponentsModule } from '@astrouxds/angular';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 
 @Component({
   selector: 'fds-outputs',
   standalone: true,
-  imports: [CommonModule, AstroComponentsModule, ReactiveFormsModule],
+  imports: [
+    CommonModule,
+    AstroComponentsModule,
+    ReactiveFormsModule,
+    NgTemplateOutlet,
+  ],
   templateUrl: './outputs.component.html',
   styleUrls: ['./outputs.component.css'],
 })

--- a/src/app/shared/tabbed-child-container/tabbed-child-container.component.css
+++ b/src/app/shared/tabbed-child-container/tabbed-child-container.component.css
@@ -11,7 +11,7 @@ header {
   gap: var(--spacing-4);
 }
 
-div {
+div, rux-tab-panels {
   box-shadow: 0 0 0 1px var(--color-border-interactive-muted);
   flex-grow: 1;
   overflow: auto;

--- a/src/app/shared/tabbed-child-container/tabbed-child-container.component.html
+++ b/src/app/shared/tabbed-child-container/tabbed-child-container.component.html
@@ -20,16 +20,13 @@
     </rux-notification>
   </ng-container>
 </header>
-<div>
+<div *ngIf="!hasTabPanels else panels">
   <ng-content></ng-content>
 </div>
-<!-- <div *ngIf="hasTabPanels else panels">
-  <ng-content></ng-content>
-</div>
+
 <ng-template #panels>
-<rux-tab-panels [attr.aria-labelledby]="tabsParentId">
-  <rux-tab-panel *ngFor="let tab of tabs" [attr.aria-labelledby]="tab.id">
-    <ng-content select="[tab][label]"></ng-content>
-  </rux-tab-panel>
-</rux-tab-panels>
-</ng-template> -->
+  <rux-tab-panels [attr.aria-labelledby]="tabsParentId">
+    <ng-content select="[panels]"></ng-content>
+  </rux-tab-panels>
+</ng-template>
+

--- a/src/app/shared/tabbed-child-container/tabbed-child-container.component.ts
+++ b/src/app/shared/tabbed-child-container/tabbed-child-container.component.ts
@@ -1,22 +1,45 @@
-import { Component, Input } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import {
+  Component,
+  ContentChildren,
+  Input,
+  QueryList,
+  TemplateRef,
+  ViewChildren,
+} from '@angular/core';
+import { CommonModule, NgTemplateOutlet } from '@angular/common';
 import { AstroComponentsModule } from '@astrouxds/angular';
+import { InputsComponent } from 'src/app/main/inputs-outputs/inputs/inputs.component';
+import { OutputsComponent } from 'src/app/main/inputs-outputs/outputs/outputs.component';
 import { Tabs } from 'src/app/types/Tabs';
 
 @Component({
   selector: 'fds-tabbed-child-container',
   standalone: true,
-  imports: [CommonModule, AstroComponentsModule],
+  imports: [
+    CommonModule,
+    AstroComponentsModule,
+    InputsComponent,
+    OutputsComponent,
+    NgTemplateOutlet,
+  ],
   templateUrl: './tabbed-child-container.component.html',
   styleUrls: ['./tabbed-child-container.component.css'],
 })
 export class TabbedChildContainerComponent {
   @Input() tabs?: Tabs[];
   @Input() tabsParentId?: string;
-  @Input() hasTabPanels: boolean = true;
+  @Input() hasTabPanels: boolean = false;
 
   @Input() notificationData?: any[];
   @Input() notificationHideClose?: boolean;
+
+  @ContentChildren('tabContent')
+  tabContents!: QueryList<any>;
+
+  ngAfterContentInit(): void {
+    console.log(this.tabContents);
+    //this.tabContents!.forEach((tabInstance) => console.log(tabInstance));
+  }
 
   onSelect(e: Event) {
     const event = e as CustomEvent;


### PR DESCRIPTION
**JIRA Ticket [Jira Issue Key](https://rocketcom.atlassian.net/browse/DEMO-371)**

This is a super minor refactor to remove commented out code and put `rux-tab-panels` inside of the shared component. 

## Issues and/or Limitations

Alas, I was not able to do get each `rux-tab-panel` to render dynamically through the shared component, so the solution is to have content wrap in `rux-tab-panel` inside of the `TabbedChildContainerComponent`.

## Final Checklist

- [ ] Works in Chrome
- [ ] Works in Firefox
- [ ] Works in Safari
- [ ] Handles responsiveness as required
- [ ] Dark theme styles are correct
- [ ] Light theme styles are correct
