### PR TITLE
Demo 377 (feat): input source view

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
   "trailingComma": "es5",
   "tabWidth": 2,
-  "semi": false,
+  "semi": true,
   "singleQuote": true
 }

--- a/src/app/main/inputs-outputs-data-display/inputs-outputs-data-display.component.css
+++ b/src/app/main/inputs-outputs-data-display/inputs-outputs-data-display.component.css
@@ -1,7 +1,7 @@
 :host {
   display: flex;
   gap: var(--spacing-4);
-  flex-grow: 1;
-  height: 100%;
+  height: calc(100% - var(--spacing-4));
   padding-inline: var(--spacing-4);
+  padding-block-end: var(--spacing-4);
 }

--- a/src/app/main/main.component.css
+++ b/src/app/main/main.component.css
@@ -1,9 +1,7 @@
-main {
-  display: block;
-  height: 100%;
+rux-container::part(body) {
+  padding: var(--spacing-0);
 }
 
-rux-container::part(body) {
-  padding-block-start: var(--spacing-0);
-  padding-inline: 0px;
+main {
+  height: 100%;
 }

--- a/src/app/main/utility-components/propagator-utility/input-source/input-source.component.css
+++ b/src/app/main/utility-components/propagator-utility/input-source/input-source.component.css
@@ -1,7 +1,7 @@
 :host {
   display: flex;
   flex-direction: column;
-  flex-grow: 1;
+  height: 100%;
 }
 
 .controls,
@@ -49,6 +49,11 @@ rux-pop-up::part(popup-content) {
 
 rux-pop-up::part(arrow) {
   display: none;
+}
+
+rux-pop-up span {
+  padding-inline-start: var(--spacing-2);
+  font-style: italic;
 }
 
 rux-input[type='number'] {

--- a/src/app/main/utility-components/propagator-utility/input-source/input-source.component.css
+++ b/src/app/main/utility-components/propagator-utility/input-source/input-source.component.css
@@ -1,3 +1,11 @@
 rux-container::part(container) {
   border: none;
 }
+
+h3 {
+  padding-block-end: 1em;
+}
+
+.form-section {
+  display: flex;
+}

--- a/src/app/main/utility-components/propagator-utility/input-source/input-source.component.css
+++ b/src/app/main/utility-components/propagator-utility/input-source/input-source.component.css
@@ -1,5 +1,26 @@
-rux-container::part(container) {
-  border: none;
+:host {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+.controls,
+footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-2);
+  background-color: var(--color-background-base-default);
+  padding: var(--spacing-4);
+}
+
+form {
+  background-color: var(--color-background-surface-default);
+  padding-inline: calc(var(--spacing-6) + 4px);
+  padding-block: var(--spacing-4);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  flex-grow: 1;
 }
 
 h3 {
@@ -8,4 +29,42 @@ h3 {
 
 .form-section {
   display: flex;
+  align-items: flex-end;
+  gap: var(--spacing-2);
+  padding-block-end: var(--spacing-4);
+}
+
+rux-pop-up {
+  width: max-content;
+}
+
+rux-pop-up::part(popup-content) {
+  min-width: 191px;
+  transform: translateY(-12px);
+
+  & rux-menu {
+    padding-inline-start: var(--spacing-2);
+  }
+}
+
+rux-pop-up::part(arrow) {
+  display: none;
+}
+
+rux-input[type='number'] {
+  width: 90px;
+}
+
+.switch-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  justify-content: flex-end;
+  padding-inline-start: var(--spacing-8);
+}
+
+.controls-panel {
+  position: relative;
+  background-color: red;
+  width: 30%;
 }

--- a/src/app/main/utility-components/propagator-utility/input-source/input-source.component.css
+++ b/src/app/main/utility-components/propagator-utility/input-source/input-source.component.css
@@ -10,7 +10,8 @@ footer {
   justify-content: flex-end;
   gap: var(--spacing-2);
   background-color: var(--color-background-base-default);
-  padding: var(--spacing-4);
+  padding-block: var(--spacing-3);
+  padding-inline: var(--spacing-4);
 }
 
 form {
@@ -70,6 +71,4 @@ rux-input[type='number'] {
 
 .controls-panel {
   position: relative;
-  background-color: red;
-  width: 30%;
 }

--- a/src/app/main/utility-components/propagator-utility/input-source/input-source.component.html
+++ b/src/app/main/utility-components/propagator-utility/input-source/input-source.component.html
@@ -1,7 +1,9 @@
 <div class="controls">
   <rux-button (click)="toggleControls()">Controls</rux-button>
 </div>
-<aside *ngIf="showControlsPanel" class="controls-panel">Controls</aside>
+<aside *ngIf="showControlsPanel" class="controls-panel">
+  <fds-propagator-controls />
+</aside>
 <form>
   <h3>Source Settings</h3>
   <section class="form-section">

--- a/src/app/main/utility-components/propagator-utility/input-source/input-source.component.html
+++ b/src/app/main/utility-components/propagator-utility/input-source/input-source.component.html
@@ -1,45 +1,58 @@
 <rux-container>
   <div class="toolbar">
-    Toolbar
-    <!-- <rux-button>Controls</rux-button> -->
+    <rux-button>Controls</rux-button>
   </div>
 
   <form>
-    Form
-    <!-- <section class="form-section">
-      <h3>Source Settings</h3>
-
+    <h3>Source Settings</h3>
+    <section class="form-section">
       <rux-select label="Orbit Source">
         <rux-option label="Ephemeris" />
         <rux-option label="TLE" />
       </rux-select>
-      <rux-input placeholder="eph_020120.ephm" />
+
+      <rux-pop-up placement="bottom" closeOnSelect="true">
+        <rux-input placeholder="eph_020120.ephm" slot="trigger" />
+        <rux-menu>
+          <span>Recent TLE Files</span>
+          <rux-menu-item>tle_12242019_1.tle</rux-menu-item>
+          <rux-menu-item>tle_12242019_1.tle</rux-menu-item>
+          <rux-menu-item>tle_12242019_1.tle</rux-menu-item>
+          <rux-menu-item>tle_12242019_1.tle</rux-menu-item>
+          <rux-menu-item>tle_12242019_1.tle</rux-menu-item>
+        </rux-menu>
+        <span>Import TLE File</span>
+      </rux-pop-up>
     </section>
 
+    <h3>Epoch Settings</h3>
     <section class="form-section">
-      <h3>Epoch Settings</h3>
-
-      <rux-select label="Orbit Source">
-        <rux-option label="Ephemeris" />
-        <rux-option label="TLE" />
-      </rux-select>
       <rux-input placeholder="eph_020120.ephm" />
+      <rux-select>
+        <rux-option label="UTCYmdHMs3" />
+      </rux-select>
+      <rux-switch label="Include Item"></rux-switch>
+      <rux-switch label="Include Item"></rux-switch>
     </section>
 
+    <h3>Date & Duration</h3>
     <section class="form-section">
-      <h3>Date & Duration</h3>
-
-      <rux-select label="Orbit Source">
-        <rux-option label="Ephemeris" />
-        <rux-option label="TLE" />
+      <rux-select label="Date Format">
+        <rux-option label="UTC YmdHMs3" />
       </rux-select>
-      <rux-input placeholder="eph_020120.ephm" />
-    </section> -->
+      <rux-input type="date" label="Start Date" placeholder="eph_020120.ephm" />
+      <rux-input
+        type="datetime-local"
+        label="End Date"
+        placeholder="eph_020120.ephm"
+      />
+      <rux-input label="Span (Days)" placeholder="#" type="number" />
+    </section>
   </form>
   <aside class="controls">Controls</aside>
 
   <div class="footer">
-    <!-- <rux-button>Secondary Action</rux-button>
-    <rux-button>Primary Action</rux-button> -->
+    <rux-button>Secondary Action</rux-button>
+    <rux-button>Primary Action</rux-button>
   </div>
 </rux-container>

--- a/src/app/main/utility-components/propagator-utility/input-source/input-source.component.html
+++ b/src/app/main/utility-components/propagator-utility/input-source/input-source.component.html
@@ -1,58 +1,57 @@
-<rux-container>
-  <div class="toolbar">
-    <rux-button>Controls</rux-button>
-  </div>
+<div class="controls">
+  <rux-button (click)="toggleControls()">Controls</rux-button>
+</div>
+<aside *ngIf="showControlsPanel" class="controls-panel">Controls</aside>
+<form>
+  <h3>Source Settings</h3>
+  <section class="form-section">
+    <rux-select label="Orbit Source">
+      <rux-option label="Ephemeris" />
+      <rux-option label="TLE" />
+    </rux-select>
 
-  <form>
-    <h3>Source Settings</h3>
-    <section class="form-section">
-      <rux-select label="Orbit Source">
-        <rux-option label="Ephemeris" />
-        <rux-option label="TLE" />
-      </rux-select>
-
-      <rux-pop-up placement="bottom" closeOnSelect="true">
-        <rux-input placeholder="eph_020120.ephm" slot="trigger" />
-        <rux-menu>
-          <span>Recent TLE Files</span>
-          <rux-menu-item>tle_12242019_1.tle</rux-menu-item>
-          <rux-menu-item>tle_12242019_1.tle</rux-menu-item>
-          <rux-menu-item>tle_12242019_1.tle</rux-menu-item>
-          <rux-menu-item>tle_12242019_1.tle</rux-menu-item>
-          <rux-menu-item>tle_12242019_1.tle</rux-menu-item>
-        </rux-menu>
+    <rux-pop-up placement="bottom" closeOnSelect="true">
+      <rux-input placeholder="eph_020120.ephm" slot="trigger" />
+      <rux-menu>
+        <span>Recent TLE Files</span>
+        <rux-menu-item>tle_12242019_1.tle</rux-menu-item>
+        <rux-menu-item>tle_12242019_1.tle</rux-menu-item>
+        <rux-menu-item>tle_12242019_1.tle</rux-menu-item>
+        <rux-menu-item>tle_12242019_1.tle</rux-menu-item>
+        <rux-menu-item>tle_12242019_1.tle</rux-menu-item>
         <span>Import TLE File</span>
-      </rux-pop-up>
-    </section>
+      </rux-menu>
+    </rux-pop-up>
+  </section>
 
-    <h3>Epoch Settings</h3>
-    <section class="form-section">
-      <rux-input placeholder="eph_020120.ephm" />
-      <rux-select>
-        <rux-option label="UTCYmdHMs3" />
-      </rux-select>
+  <h3>Epoch Settings</h3>
+  <section class="form-section">
+    <rux-input
+      type="datetime-local"
+      label="Epoch"
+      placeholder="YYY/MM/DD 00:00:00"
+    />
+    <rux-select>
+      <rux-option label="UTCYmdHMs3" />
+    </rux-select>
+    <div class="switch-wrapper">
       <rux-switch label="Include Item"></rux-switch>
       <rux-switch label="Include Item"></rux-switch>
-    </section>
+    </div>
+  </section>
 
-    <h3>Date & Duration</h3>
-    <section class="form-section">
-      <rux-select label="Date Format">
-        <rux-option label="UTC YmdHMs3" />
-      </rux-select>
-      <rux-input type="date" label="Start Date" placeholder="eph_020120.ephm" />
-      <rux-input
-        type="datetime-local"
-        label="End Date"
-        placeholder="eph_020120.ephm"
-      />
-      <rux-input label="Span (Days)" placeholder="#" type="number" />
-    </section>
-  </form>
-  <aside class="controls">Controls</aside>
+  <h3>Date & Duration Settings</h3>
+  <section class="form-section">
+    <rux-select label="Date Format">
+      <rux-option label="UTC YmdHMs3" />
+    </rux-select>
+    <rux-input type="date" label="Start Date" placeholder="eph_020120.ephm" />
+    <rux-input type="time" label="Start Time" placeholder="eph_020120.ephm" />
+    <rux-input type="number" min="0" label="Span (Days)" placeholder="#" />
+  </section>
+</form>
 
-  <div class="footer">
-    <rux-button>Secondary Action</rux-button>
-    <rux-button>Primary Action</rux-button>
-  </div>
-</rux-container>
+<footer>
+  <rux-button>Secondary Action</rux-button>
+  <rux-button>Primary Action</rux-button>
+</footer>

--- a/src/app/main/utility-components/propagator-utility/input-source/input-source.component.ts
+++ b/src/app/main/utility-components/propagator-utility/input-source/input-source.component.ts
@@ -1,10 +1,11 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AstroComponentsModule } from '@astrouxds/angular';
+import { PropagatorControlsComponent } from '../propagator-controls/propagator-controls.component';
 @Component({
   selector: 'fds-input-source',
   standalone: true,
-  imports: [CommonModule, AstroComponentsModule],
+  imports: [CommonModule, AstroComponentsModule, PropagatorControlsComponent],
   templateUrl: './input-source.component.html',
   styleUrls: ['./input-source.component.css'],
 })

--- a/src/app/main/utility-components/propagator-utility/input-source/input-source.component.ts
+++ b/src/app/main/utility-components/propagator-utility/input-source/input-source.component.ts
@@ -6,8 +6,12 @@ import { AstroComponentsModule } from '@astrouxds/angular';
   standalone: true,
   imports: [CommonModule, AstroComponentsModule],
   templateUrl: './input-source.component.html',
-  styleUrls: ['./input-source.component.css']
+  styleUrls: ['./input-source.component.css'],
 })
 export class InputSourceComponent {
+  showControlsPanel: boolean = false;
 
+  toggleControls() {
+    this.showControlsPanel = !this.showControlsPanel;
+  }
 }

--- a/src/app/main/utility-components/propagator-utility/propagator-controls/propagator-controls.component.css
+++ b/src/app/main/utility-components/propagator-utility/propagator-controls/propagator-controls.component.css
@@ -1,0 +1,62 @@
+:host {
+  position: absolute;
+  right: 0px;
+  height: 510px;
+  width: 400px;
+  z-index: 2;
+}
+
+rux-container::part(body) {
+  padding-block: var(--spacing-0);
+  overflow: auto;
+}
+
+div[slot='footer'] {
+  display: flex;
+  justify-content: space-around;
+  gap: var(--spacing-2);
+
+  & rux-button::part(container) {
+    width: 150px;
+  }
+}
+
+section {
+  border-bottom: 1px solid var(--color-border-interactive-muted);
+  padding-block: var(--spacing-4);
+}
+
+h3 {
+  padding-block-end: var(--spacing-2);
+}
+
+h4 {
+  padding-block: var(--spacing-2);
+}
+
+section rux-input,
+section rux-select {
+  width: 45%;
+}
+
+.row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+}
+
+.column {
+  display: flex;
+  flex-direction: column;
+}
+
+section span {
+  display: flex;
+  align-items: flex-end;
+  padding-block: var(--spacing-2);
+  border-bottom: 1px solid var(--color-border-interactive-muted);
+}
+
+section span rux-icon {
+  margin-left: auto;
+}

--- a/src/app/main/utility-components/propagator-utility/propagator-controls/propagator-controls.component.html
+++ b/src/app/main/utility-components/propagator-utility/propagator-controls/propagator-controls.component.html
@@ -1,0 +1,57 @@
+<rux-container>
+  <span slot="header">Controls</span>
+  <div slot="toolbar">
+    <rux-select label="Propagator">
+      <rux-option label="Bulirsch-Stoer Cowell" />
+    </rux-select>
+  </div>
+
+  <form>
+    <section>
+      <h3>Force Model Controls</h3>
+      <div class="row">
+        <rux-input label="F10.7 Flux:" placeholder="000"></rux-input>
+        <rux-select>
+          <rux-option label="flux-units" />
+        </rux-select>
+      </div>
+    </section>
+
+    <section>
+      <h3>Gravitational Model</h3>
+      <div class="column">
+        <span
+          ><rux-checkbox>Lunar Gravity</rux-checkbox
+          ><rux-icon size="small" icon="keyboard-arrow-right"
+        /></span>
+        <span
+          ><rux-checkbox>Planetary Gravity</rux-checkbox
+          ><rux-icon size="small" icon="keyboard-arrow-right"
+        /></span>
+        <span
+          ><rux-checkbox>Solar Gravity</rux-checkbox
+          ><rux-icon size="small" icon="keyboard-arrow-right"
+        /></span>
+      </div>
+
+      <h4>Earth Gravity</h4>
+      <div class="row">
+        <rux-input label="Degree" placeholder="10"></rux-input>
+        <rux-input label="Order" placeholder="10"></rux-input>
+      </div>
+    </section>
+
+    <section>
+      <h3>Perturbations</h3>
+      <span>
+        <rux-checkbox>Atmospheric Drag</rux-checkbox>
+        <rux-icon size="small" icon="keyboard-arrow-down" />
+      </span>
+    </section>
+  </form>
+
+  <div slot="footer">
+    <rux-button secondary>Cancel</rux-button>
+    <rux-button>Save</rux-button>
+  </div>
+</rux-container>

--- a/src/app/main/utility-components/propagator-utility/propagator-controls/propagator-controls.component.spec.ts
+++ b/src/app/main/utility-components/propagator-utility/propagator-controls/propagator-controls.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PropagatorControlsComponent } from './propagator-controls.component';
+
+describe('PropagatorControlsComponent', () => {
+  let component: PropagatorControlsComponent;
+  let fixture: ComponentFixture<PropagatorControlsComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [PropagatorControlsComponent]
+    });
+    fixture = TestBed.createComponent(PropagatorControlsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/main/utility-components/propagator-utility/propagator-controls/propagator-controls.component.ts
+++ b/src/app/main/utility-components/propagator-utility/propagator-controls/propagator-controls.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AstroComponentsModule } from '@astrouxds/angular';
+
+@Component({
+  selector: 'fds-propagator-controls',
+  standalone: true,
+  imports: [CommonModule, AstroComponentsModule],
+  templateUrl: './propagator-controls.component.html',
+  styleUrls: ['./propagator-controls.component.css'],
+})
+export class PropagatorControlsComponent {}

--- a/src/app/main/utility-components/propagator-utility/propagator-utility.component.css
+++ b/src/app/main/utility-components/propagator-utility/propagator-utility.component.css
@@ -1,12 +1,20 @@
-rux-container::part(container) {
-  border: none;
+:host {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 header {
   display: flex;
+  align-items: center;
   gap: 0.5rem;
+  padding: var(--spacing-4);
 }
 
 header button {
   margin-inline-start: auto;
+}
+
+rux-tab-panel {
+  height: 100%;
 }

--- a/src/app/main/utility-components/propagator-utility/propagator-utility.component.html
+++ b/src/app/main/utility-components/propagator-utility/propagator-utility.component.html
@@ -1,20 +1,21 @@
-<rux-container class="utility">
-  <header slot="header">
-    <rux-icon icon="public" size="small" />Propagator Utility
-    <button (click)="navigateBack()">Back</button>
-  </header>
+<header slot="header">
+  <rux-icon icon="public" size="small" />
+  <h2>Propagator Utility</h2>
+  <button (click)="navigateBack()">Back</button>
+</header>
 
-  <rux-tabs id="propagator-tabs" slot="tab-bar">
-    <rux-tab id="input-source" small selected="true">Input Source</rux-tab>
-    <rux-tab id="view-orbit" small>View Orbit</rux-tab>
-  </rux-tabs>
-
-  <rux-tab-panels aria-labelledby="propagator-tabs">
+<fds-tabbed-child-container
+  [tabs]="tabs"
+  [hasTabPanels]="true"
+  tabsParentId="propagator-tabs"
+  [isUtilityContainer]="true"
+>
+  <ng-container panels>
     <rux-tab-panel aria-labelledby="input-source">
-      <fds-input-source></fds-input-source>
+      <fds-input-source />
     </rux-tab-panel>
     <rux-tab-panel aria-labelledby="view-orbit">
-      <fds-view-orbit></fds-view-orbit>
+      <fds-view-orbit />
     </rux-tab-panel>
-  </rux-tab-panels>
-</rux-container>
+  </ng-container>
+</fds-tabbed-child-container>

--- a/src/app/main/utility-components/propagator-utility/propagator-utility.component.ts
+++ b/src/app/main/utility-components/propagator-utility/propagator-utility.component.ts
@@ -2,21 +2,35 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AstroComponentsModule } from '@astrouxds/angular';
 import { Router, RouterLink, RouterOutlet } from '@angular/router';
-import { InputSourceComponent } from "./input-source/input-source.component"
+import { InputSourceComponent } from './input-source/input-source.component';
 import { ViewOrbitComponent } from './view-orbit/view-orbit.component';
+import { TabbedChildContainerComponent } from 'src/app/shared/tabbed-child-container/tabbed-child-container.component';
+import { Tabs } from 'src/app/types/Tabs';
 
 @Component({
   selector: 'fds-propagator-util',
   standalone: true,
-  imports: [AstroComponentsModule, RouterLink, RouterOutlet, CommonModule, InputSourceComponent, ViewOrbitComponent],
+  imports: [
+    AstroComponentsModule,
+    TabbedChildContainerComponent,
+    RouterLink,
+    RouterOutlet,
+    CommonModule,
+    InputSourceComponent,
+    ViewOrbitComponent,
+  ],
   templateUrl: './propagator-utility.component.html',
   styleUrls: ['./propagator-utility.component.css'],
 })
 export class PropagatorUtilityComponent {
-  constructor(private router: Router) { }
-  
-  navigateBack() {
-    this.router.navigateByUrl('/')
-  }
+  constructor(private router: Router) {}
 
+  tabs: Tabs[] = [
+    { label: 'Input Source', id: 'input-source', selected: true },
+    { label: 'View Orbit', id: 'view-orbit', selected: false },
+  ];
+
+  navigateBack() {
+    this.router.navigateByUrl('/');
+  }
 }

--- a/src/app/main/utility-components/propagator-utility/view-orbit/view-orbit.component.html
+++ b/src/app/main/utility-components/propagator-utility/view-orbit/view-orbit.component.html
@@ -1,12 +1,10 @@
-<rux-container>
-  <div class="toolbar">Toolbar</div>
+<div class="toolbar">Toolbar</div>
 
-  <section>
-    <div>Visualization Controls</div>
-    <div>Visualization</div>
-  </section>
+<section>
+  <div>Visualization Controls</div>
+  <div>Visualization</div>
+</section>
 
-  <aside class="controls">Controls</aside>
+<aside class="controls">Controls</aside>
 
-  <div class="footer">Playback controls</div>
-</rux-container>
+<footer class="footer">Playback controls</footer>

--- a/src/app/shared/tabbed-child-container/tabbed-child-container.component.css
+++ b/src/app/shared/tabbed-child-container/tabbed-child-container.component.css
@@ -11,8 +11,22 @@ header {
   gap: var(--spacing-4);
 }
 
-div, rux-tab-panels {
+div,
+rux-tab-panels {
   box-shadow: 0 0 0 1px var(--color-border-interactive-muted);
   flex-grow: 1;
   overflow: hidden;
+}
+
+:host.utility-container {
+  row-gap: 0px;
+  justify-content: space-between;
+}
+
+:host.utility-container rux-tabs {
+  padding-inline: var(--spacing-4);
+}
+
+:host.utility-container rux-tab-panels {
+  box-shadow: none;
 }

--- a/src/app/shared/tabbed-child-container/tabbed-child-container.component.html
+++ b/src/app/shared/tabbed-child-container/tabbed-child-container.component.html
@@ -16,11 +16,11 @@
       [status]="notificationData[0].status"
     >
       {{ notificationData[0].message }}
-      {{ notificationData[0].timestamp | date: "short" }}
+      {{ notificationData[0].timestamp | date: 'short' }}
     </rux-notification>
   </ng-container>
 </header>
-<div *ngIf="!hasTabPanels else panels">
+<div *ngIf="!hasTabPanels; else panels">
   <ng-content></ng-content>
 </div>
 
@@ -29,4 +29,3 @@
     <ng-content select="[panels]"></ng-content>
   </rux-tab-panels>
 </ng-template>
-

--- a/src/app/shared/tabbed-child-container/tabbed-child-container.component.ts
+++ b/src/app/shared/tabbed-child-container/tabbed-child-container.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, HostBinding } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AstroComponentsModule } from '@astrouxds/angular';
 import { Tabs } from 'src/app/types/Tabs';
@@ -17,6 +17,12 @@ export class TabbedChildContainerComponent {
 
   @Input() notificationData?: any[];
   @Input() notificationHideClose?: boolean;
+
+  @Input() isUtilityContainer?: boolean = false;
+
+  @HostBinding('class.utility-container') get isUtility() {
+    return this.isUtilityContainer;
+  }
 
   onSelect(e: Event) {
     const event = e as CustomEvent;


### PR DESCRIPTION
**JIRA Ticket [DEMO-377](https://rocketcom.atlassian.net/browse/DEMO-377)**

## Brief Description

This PR adds the content of the input source tab in the propagator utility. It also adds the controls drawer from the wireframes which can possibly be used in both the input source and view orbit tabs. 

## Issues and/or Limitations

The static height of the controls drawer is not ideal and should really be bound to the height of the input source tab panel to be truly responsive however I deemed that out of scope for just getting the scaffolding in. 

## Final Checklist

- [X] Works in Chrome
- [X] Works in Firefox
- [X] Works in Safari
- [ ] Handles responsiveness as required
- [X] Dark theme styles are correct
- [X] Light theme styles are correct
