### PR TITLE
DEMO-422 (feat): reshaping state to include spacecrafts entity

### DIFF
--- a/src/app/+state/app.actions.ts
+++ b/src/app/+state/app.actions.ts
@@ -1,5 +1,10 @@
 import { createActionGroup, emptyProps, props } from '@ngrx/store';
-import { ProcessedTrackFile, Scenario, TrackFile } from '../types/data.types';
+import {
+  ProcessedTrackFile,
+  Scenario,
+  Spacecraft,
+  TrackFile,
+} from '../types/data.types';
 
 export const AppActions = createActionGroup({
   source: 'App',
@@ -11,6 +16,8 @@ export const AppActions = createActionGroup({
 export const SpacecraftActions = createActionGroup({
   source: 'Spacecraft',
   events: {
+    'Spacecrafts Requested': emptyProps(),
+    'Spacecrafts Retrieved': props<{ spacecrafts: Spacecraft[] }>(),
     'Spacecraft Id Selected': props<{ spacecraftId: string }>(),
   },
 });
@@ -30,7 +37,10 @@ export const TrackFilesActions = createActionGroup({
     'Track Files Requested': emptyProps(),
     'Track Files Retrieved': props<{ trackFiles: TrackFile[] }>(),
     'Track File Selected': props<{ trackFileId: string }>(),
-    "Track File Modified": props<{ trackFileId: string, updatedTrackFile: TrackFile}>(),
+    'Track File Modified': props<{
+      trackFileId: string;
+      updatedTrackFile: TrackFile;
+    }>(),
     'Track File Processed': props<{
       processedTrackFile: ProcessedTrackFile;
       trackFileId: string;

--- a/src/app/+state/app.adapters.ts
+++ b/src/app/+state/app.adapters.ts
@@ -1,5 +1,5 @@
 import { EntityAdapter, createEntityAdapter } from '@ngrx/entity';
-import { Scenario, TrackFile } from '../types/data.types';
+import { Scenario, Spacecraft, TrackFile } from '../types/data.types';
 
 export function sortByName(
   a: Scenario | TrackFile,
@@ -9,8 +9,8 @@ export function sortByName(
 }
 
 export function sortById(
-  a: Scenario | TrackFile,
-  b: Scenario | TrackFile
+  a: Scenario | TrackFile | Spacecraft,
+  b: Scenario | TrackFile | Spacecraft
 ): number {
   return a.id.localeCompare(b.id);
 }
@@ -18,6 +18,11 @@ export function sortById(
 export const scenarioAdapter: EntityAdapter<Scenario> =
   createEntityAdapter<Scenario>({
     sortComparer: sortByName,
+  });
+
+export const spacecraftAdapter: EntityAdapter<Spacecraft> =
+  createEntityAdapter<Spacecraft>({
+    sortComparer: sortById,
   });
 
 export const trackFileAdapter: EntityAdapter<TrackFile> =

--- a/src/app/+state/app.effects.ts
+++ b/src/app/+state/app.effects.ts
@@ -1,5 +1,9 @@
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { ScenariosActions, TrackFilesActions } from './app.actions';
+import {
+  ScenariosActions,
+  SpacecraftActions,
+  TrackFilesActions,
+} from './app.actions';
 import { exhaustMap, map } from 'rxjs';
 import { inject } from '@angular/core';
 import { MockDataService } from '../api/mock-data.service';
@@ -12,6 +16,21 @@ const loadScenarios = createEffect(
         return scenarioService.getScenarios().pipe(
           map((scenarios) => {
             return ScenariosActions.scenariosRetrieved({ scenarios });
+          })
+        );
+      })
+    ),
+  { functional: true }
+);
+
+const loadSpacecrafts = createEffect(
+  (spacecraftService = inject(MockDataService)) =>
+    inject(Actions).pipe(
+      ofType(SpacecraftActions.spacecraftsRequested),
+      exhaustMap(() => {
+        return spacecraftService.getSpacecrafts().pipe(
+          map((spacecrafts) => {
+            return SpacecraftActions.spacecraftsRetrieved({ spacecrafts });
           })
         );
       })
@@ -36,5 +55,6 @@ const loadTrackFiles = createEffect(
 
 export const AppEffects = {
   loadScenarios,
+  loadSpacecrafts,
   loadTrackFiles,
 };

--- a/src/app/+state/app.model.ts
+++ b/src/app/+state/app.model.ts
@@ -1,8 +1,9 @@
-import { Scenario, TrackFile } from '../types/data.types';
+import { Scenario, Spacecraft, TrackFile } from '../types/data.types';
 import { EntityState } from '@ngrx/entity';
 
 export interface AppStore {
   scenarios: ScenariosState;
+  spacecrafts: SpacecraftsState;
   trackFiles: TrackFilesState;
   selectedSpacecraftId: string | null;
   selectedTrackFileId: string | null;
@@ -10,5 +11,7 @@ export interface AppStore {
 }
 
 export interface ScenariosState extends EntityState<Scenario> {}
+
+export interface SpacecraftsState extends EntityState<Spacecraft> {}
 
 export interface TrackFilesState extends EntityState<TrackFile> {}

--- a/src/app/+state/app.reducer.ts
+++ b/src/app/+state/app.reducer.ts
@@ -5,16 +5,30 @@ import {
   TrackFilesActions,
   AppActions,
 } from './app.actions';
-import { AppStore, ScenariosState, TrackFilesState } from './app.model';
-import { scenarioAdapter, trackFileAdapter } from './app.adapters';
+import {
+  AppStore,
+  ScenariosState,
+  SpacecraftsState,
+  TrackFilesState,
+} from './app.model';
+import {
+  scenarioAdapter,
+  spacecraftAdapter,
+  trackFileAdapter,
+} from './app.adapters';
 
 const initialScenarios: ScenariosState = scenarioAdapter.getInitialState({});
+
+const initialSpacecrafts: SpacecraftsState = spacecraftAdapter.getInitialState(
+  {}
+);
 
 const initialTrackFiles: TrackFilesState = trackFileAdapter.getInitialState({});
 
 export const initialState: AppStore = {
   scenarios: initialScenarios,
   trackFiles: initialTrackFiles,
+  spacecrafts: initialSpacecrafts,
   selectedSpacecraftId: null,
   selectedScenarioId: null,
   selectedTrackFileId: null,
@@ -26,14 +40,15 @@ export const AppReducer = createReducer(
   //Appwide Actions
   on(AppActions.initializeIds, (state) => {
     const selectedScenario = state.scenarios.entities[state.scenarios.ids[0]];
-    const selectedSpacecraft = selectedScenario?.spaceCraft[0];
-    const selectedTrackFileId = selectedSpacecraft?.trackFileIds[0] || null;
+    const selectedSpacecraftId = selectedScenario!.spaceCraftIds[0].id;
+    const selectedTrackFileId =
+      state.spacecrafts.entities[selectedSpacecraftId]!.trackFileIds[0] || null;
 
     return {
       ...state,
       selectedTrackFileId,
       selectedScenarioId: selectedScenario?.id || null,
-      selectedSpacecraftId: selectedSpacecraft?.id || null,
+      selectedSpacecraftId: selectedSpacecraftId || null,
     };
   }),
 
@@ -68,15 +83,22 @@ export const AppReducer = createReducer(
     ...state,
     selectedTrackFileId: trackFileId,
   })),
-  on(TrackFilesActions.trackFileModified, (state, {trackFileId, updatedTrackFile}) => ({
-    ...state,
-    trackFiles: trackFileAdapter.updateOne({
-      id: trackFileId,
-      changes: {
-        ...state.trackFiles.entities[trackFileId], ...updatedTrackFile
-      }
-    }, state.trackFiles)
-  })),
+  on(
+    TrackFilesActions.trackFileModified,
+    (state, { trackFileId, updatedTrackFile }) => ({
+      ...state,
+      trackFiles: trackFileAdapter.updateOne(
+        {
+          id: trackFileId,
+          changes: {
+            ...state.trackFiles.entities[trackFileId],
+            ...updatedTrackFile,
+          },
+        },
+        state.trackFiles
+      ),
+    })
+  ),
   on(
     TrackFilesActions.trackFileProcessed,
     (state, { trackFileId, processedTrackFile }) => ({
@@ -95,6 +117,12 @@ export const AppReducer = createReducer(
   ),
 
   // Spacecraft actions
+  on(SpacecraftActions.spacecraftsRetrieved, (state, { spacecrafts }) => {
+    return {
+      ...state,
+      spacecrafts: spacecraftAdapter.addMany(spacecrafts, initialSpacecrafts),
+    };
+  }),
   on(SpacecraftActions.spacecraftIdSelected, (state, { spacecraftId }) => ({
     ...state,
     selectedSpacecraftId: spacecraftId,

--- a/src/app/+state/app.selectors.ts
+++ b/src/app/+state/app.selectors.ts
@@ -1,7 +1,11 @@
 import { createSelector } from '@ngrx/store';
 import { Spacecraft, SpacecraftEntity, TrackFile } from '../types/data.types';
 import { ScenariosState } from './app.model';
-import { scenarioAdapter, trackFileAdapter } from './app.adapters';
+import {
+  scenarioAdapter,
+  spacecraftAdapter,
+  trackFileAdapter,
+} from './app.adapters';
 import { appFeature } from './app.reducer';
 
 export const {
@@ -9,6 +13,7 @@ export const {
   reducer,
   selectAppState,
   selectScenarios,
+  selectSpacecrafts,
   selectTrackFiles,
   selectSelectedSpacecraftId,
   selectSelectedScenarioId,
@@ -23,26 +28,15 @@ export const {
   selectAll: selectAllTrackFiles,
   selectEntities: selectTrackFileEntities,
 } = trackFileAdapter.getSelectors(selectTrackFiles);
-
-export const selectAllSpacecrafts = createSelector(
-  selectScenarios,
-  (state: ScenariosState) => {
-    let spacecrafts: Spacecraft[] = [];
-    state.ids.map((id) => {
-      state.entities[id]?.spaceCraft.map((craft) => spacecrafts.push(craft));
-    });
-    const spacecraftsEntity: SpacecraftEntity = spacecrafts.reduce(
-      (prev, next) => ({ ...prev, [next.id]: next }),
-      {}
-    );
-    return spacecraftsEntity;
-  }
-);
+export const {
+  selectAll: selectAllSpacecrafts,
+  selectEntities: selectSpacecraftEntities,
+} = spacecraftAdapter.getSelectors(selectSpacecrafts);
 
 export const selectCurrentSpacecraft = createSelector(
-  selectAllSpacecrafts,
+  selectSpacecraftEntities,
   selectSelectedSpacecraftId,
-  (spacecrafts: SpacecraftEntity, spacecraftId: string | null) => {
+  (spacecrafts, spacecraftId: string | null) => {
     if (!spacecraftId) return null;
     return spacecrafts[spacecraftId];
   }

--- a/src/app/api/mock-data.service.ts
+++ b/src/app/api/mock-data.service.ts
@@ -3,9 +3,10 @@ import { BehaviorSubject } from 'rxjs';
 import {
   generateProcessedTrackFile,
   mockScenarios,
+  mockSpaceCrafts,
   mockTrackFiles,
 } from '../mock-data/generate-data';
-import { Scenario, TrackFile } from '../types/data.types';
+import { Scenario, Spacecraft, TrackFile } from '../types/data.types';
 
 @Injectable({
   providedIn: 'root',
@@ -13,6 +14,10 @@ import { Scenario, TrackFile } from '../types/data.types';
 export class MockDataService {
   getScenarios() {
     return new BehaviorSubject<Scenario[]>(mockScenarios).asObservable();
+  }
+
+  getSpacecrafts() {
+    return new BehaviorSubject<Spacecraft[]>(mockSpaceCrafts).asObservable();
   }
 
   getTrackFiles() {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -19,6 +19,7 @@ import {
   ScenariosActions,
   TrackFilesActions,
   AppActions,
+  SpacecraftActions,
 } from './+state/app.actions';
 
 @Component({
@@ -52,6 +53,7 @@ export class AppComponent {
     private router: Router
   ) {
     this.store.dispatch(ScenariosActions.scenariosRequested());
+    this.store.dispatch(SpacecraftActions.spacecraftsRequested());
     this.store.dispatch(TrackFilesActions.trackFilesRequested());
     this.store.dispatch(AppActions.initializeIds());
     this.toasts

--- a/src/app/core/scenario-library/scenario-library.component.html
+++ b/src/app/core/scenario-library/scenario-library.component.html
@@ -10,13 +10,13 @@
       [attr.expanded]="scenario === (scenarios$ | async )![0]"
     >
       {{ scenario?.name }}
-      <ng-container *ngFor="let spacecraft of scenario?.spaceCraft">
+      <ng-container *ngFor="let spacecraftId of scenario?.spaceCraftIds">
         <rux-tree-node
           slot="node"
-          (ruxtreenodeselected)="onSpacecraftSelected(spacecraft, scenario!)"
-          [selected]="(selectedSpacecraftId$ | async) === spacecraft.id"
+          (ruxtreenodeselected)="onSpacecraftSelected(spacecraftId.id, scenario!)"
+          [selected]="(selectedSpacecraftId$ | async) === spacecraftId.id"
         >
-          {{ spacecraft.catalogId }}
+          {{ spacecraftId.catalogId }}
         </rux-tree-node>
       </ng-container>
     </rux-tree-node>

--- a/src/app/core/scenario-library/scenario-library.component.ts
+++ b/src/app/core/scenario-library/scenario-library.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { AstroComponentsModule } from '@astrouxds/angular';
-import { Store } from '@ngrx/store';
+import { select, Store } from '@ngrx/store';
 import {
   ScenariosActions,
   SpacecraftActions,
@@ -10,12 +10,14 @@ import {
 import {
   selectAllScenarios,
   selectSelectedSpacecraftId,
+  selectSpacecraftEntities,
 } from '../../+state/app.selectors';
 import { ToastService } from '../../shared/toast.service';
 import { Scenario, Spacecraft } from '../../types/data.types';
 import { Router } from '@angular/router';
 import { AppStore } from 'src/app/+state/app.model';
-import { Observable } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
+import { Dictionary } from '@ngrx/entity';
 @Component({
   standalone: true,
   selector: 'fds-scenario-library',
@@ -28,6 +30,10 @@ export class ScenarioLibraryComponent {
     selectSelectedSpacecraftId
   );
   scenarios$: Observable<Scenario[]> = this.store.select(selectAllScenarios);
+  spacecrafts: Dictionary<Spacecraft> | null | undefined;
+  spacecrafts$: Subscription = this.store
+    .pipe(select(selectSpacecraftEntities))
+    .subscribe((result) => (this.spacecrafts = result));
 
   constructor(
     private toasts: ToastService,
@@ -41,29 +47,23 @@ export class ScenarioLibraryComponent {
     scenario.setExpanded(!scenario.expanded);
   }
 
-  onSpacecraftSelected(spacecraft: Spacecraft, scenario: Scenario) {
+  onSpacecraftSelected(spacecraftId: string, scenario: Scenario) {
     this.store.dispatch(
-      SpacecraftActions.spacecraftIdSelected({ spacecraftId: spacecraft.id })
+      SpacecraftActions.spacecraftIdSelected({ spacecraftId: spacecraftId })
     );
     this.store.dispatch(
       ScenariosActions.scenarioSelected({ scenarioId: scenario.id })
     );
     this.store.dispatch(
       TrackFilesActions.trackFileSelected({
-        trackFileId: spacecraft.trackFileIds[0],
-      })
-    );
-
-    this.store.dispatch(
-      TrackFilesActions.trackFileSelected({
-        trackFileId: spacecraft.trackFileIds[0],
+        trackFileId: this.spacecrafts![spacecraftId]!.trackFileIds[0],
       })
     );
 
     this.router.navigateByUrl(
-      `${scenario.name.trim().replace(/\s/g, '-')}-${spacecraft.catalogId
-        .trim()
-        .replace(/\s/g, '-')}` || ''
+      `${scenario.name.trim().replace(/\s/g, '-')}-${this.spacecrafts![
+        spacecraftId
+      ]!.catalogId.trim().replace(/\s/g, '-')}` || ''
     );
   }
 
@@ -81,4 +81,9 @@ export class ScenarioLibraryComponent {
       closeAfter: 3000,
     });
   }
+}
+function selectAllSpacecraftEntities(
+  selectAllSpacecraftEntities: any
+): Observable<Spacecraft[]> {
+  throw new Error('Function not implemented.');
 }

--- a/src/app/core/scenario-library/scenario-library.component.ts
+++ b/src/app/core/scenario-library/scenario-library.component.ts
@@ -18,6 +18,7 @@ import { Router } from '@angular/router';
 import { AppStore } from 'src/app/+state/app.model';
 import { Observable, Subscription } from 'rxjs';
 import { Dictionary } from '@ngrx/entity';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 @Component({
   standalone: true,
   selector: 'fds-scenario-library',
@@ -32,7 +33,7 @@ export class ScenarioLibraryComponent {
   scenarios$: Observable<Scenario[]> = this.store.select(selectAllScenarios);
   spacecrafts: Dictionary<Spacecraft> | null | undefined;
   spacecrafts$: Subscription = this.store
-    .pipe(select(selectSpacecraftEntities))
+    .pipe(takeUntilDestroyed(), select(selectSpacecraftEntities))
     .subscribe((result) => (this.spacecrafts = result));
 
   constructor(

--- a/src/app/guards/valid-spacecraft.guard.ts
+++ b/src/app/guards/valid-spacecraft.guard.ts
@@ -13,7 +13,7 @@ export const validSpacecraftGuard: CanActivateFn = (route, state) => {
   const getRoutes = (scenarios: Scenario[]) => {
     let routes: string[] = [];
     scenarios.map((scenario) => {
-      scenario.spaceCraft.map((craft) => {
+      scenario.spaceCraftIds.map((craft) => {
         routes.push(
           `${scenario.name.trim().replace(/\s/g, '-')}-${craft.catalogId
             .trim()

--- a/src/app/mock-data/generate-data.ts
+++ b/src/app/mock-data/generate-data.ts
@@ -16,19 +16,21 @@ const generateScenario = (scenarioName: string): Scenario => {
   return {
     id: crypto.randomUUID(),
     name: scenarioName,
-    spaceCraft: Array(numOfSpaceCraft)
+    spaceCraftIds: Array(numOfSpaceCraft)
       .fill(null)
-      .map(() => generateSpacecraft()),
+      .map(() => ({
+        id: crypto.randomUUID(),
+        catalogId: 'IRON ' + faker.number.int({ min: 1000, max: 9999 }),
+      })),
   };
 };
 
-const generateSpacecraft = (): Spacecraft => {
-  const catalogIdNum = faker.number.int({ min: 1000, max: 9999 });
+const generateSpacecraft = (id: string, catalogId: string): Spacecraft => {
   const trackFileArrayLength = faker.number.int({ min: 20, max: 30 });
 
   return {
-    id: crypto.randomUUID(),
-    catalogId: 'IRON ' + catalogIdNum,
+    id: id,
+    catalogId: catalogId,
     trackFileIds: Array.from(Array(trackFileArrayLength), (_) =>
       faker.string.uuid()
     ),
@@ -231,15 +233,21 @@ const scenarioNames = ['Nominal OD', 'Post SK', 'Training'];
 export const mockScenarios = scenarioNames.map((name) =>
   generateScenario(name)
 );
-const spaceCraft = mockScenarios.flatMap((scenario) => scenario.spaceCraft);
+export const mockSpaceCrafts = mockScenarios.flatMap((scenario) => {
+  return scenario.spaceCraftIds.map((craftIdObject) =>
+    generateSpacecraft(craftIdObject.id, craftIdObject.catalogId)
+  );
+});
 const trackFileIdsBySpaceCraftId: { [key: string]: string[] } = {};
-spaceCraft.forEach((spacecraft) => {
+mockSpaceCrafts.forEach((spacecraft) => {
   trackFileIdsBySpaceCraftId[spacecraft.id] = spacecraft.trackFileIds;
 });
 export const mockTrackFiles = Object.entries(
   trackFileIdsBySpaceCraftId
 ).flatMap(([spacecraftId, trackFileIds]) => {
-  return trackFileIds.map((id, index) => generateTrackFile(spacecraftId, id, index));
+  return trackFileIds.map((id, index) =>
+    generateTrackFile(spacecraftId, id, index)
+  );
 });
 
 export const randomNum = (min = 1e9, max = 9e9) => {

--- a/src/app/types/data.types.ts
+++ b/src/app/types/data.types.ts
@@ -1,7 +1,12 @@
+interface SpaceCraftIds {
+  id: string;
+  catalogId: string;
+}
+
 export type Scenario = {
   id: string;
   name: string;
-  spaceCraft: Spacecraft[];
+  spaceCraftIds: SpaceCraftIds[];
 };
 
 export type ScenarioEntity = {
@@ -55,7 +60,7 @@ export type TrackFile = {
   processedTrackFile: ProcessedTrackFile | null;
   initialOrbitProperties: OrbitProperties;
   //!Todo: this is a temp data holder until we decide what 'edit track file' is supposed to do
-  comment?: string
+  comment?: string;
 };
 
 export type TrackFileEntity = {


### PR DESCRIPTION
**JIRA Ticket [DEMO-422](https://rocketcom.atlassian.net/browse/DEMO-422)**

## Brief Description

This PR is a reshaping of global state so that spacecrafts are held as their own entity, instead of as an array of objects on the scenarios entity. The scenarios entity has also been changed so that instead of an array of Spacecrafts, it holds an array of objects which contain spacecraft Ids, both the id and catalogId. I included both at Jacob's suggestion and it was super useful for correcting the route guards.

## Issues and/or Limitations

Obviously this PR has ramifications throughout the entire app. Amazingly I didn't have to make a lot of changes to the selectors, and the other file changes were relatively minimal, but be fore-warned. I also had to make some large-ish changes to the mock data generation.

## Final Checklist

- [ ] Works in Chrome
- [ ] Works in Firefox
- [ ] Works in Safari
- [ ] Handles responsiveness as required
- [ ] Dark theme styles are correct
- [ ] Light theme styles are correct
