### PR TITLE
DEMO 429 (chore): Implement Tab Panels in Track-Data

### DIFF
--- a/src/app/main/utility-components/track-data-utility/track-data-utility.component.html
+++ b/src/app/main/utility-components/track-data-utility/track-data-utility.component.html
@@ -1,17 +1,19 @@
-<fds-tabbed-child-container
-  [tabs]="tabs"
-  [hasTabPanels]="true"
-  tabsParentId="track-data-tabs"
-  [isUtilityContainer]="true"
->
-  <ng-container panels>
-    <rux-tab-panel aria-labelledby="files">
-      <fds-track-files />
-    </rux-tab-panel>
-    <div (mousedown)="renderChart()">
+<!-- To ensure the chart renders in Chrome and Safari-->
+<div (mousemove)="renderChart()">
+  <fds-tabbed-child-container
+    [tabs]="tabs"
+    [hasTabPanels]="true"
+    tabsParentId="track-data-tabs"
+    [isUtilityContainer]="true"
+  >
+    <ng-container panels>
+      <rux-tab-panel aria-labelledby="files">
+        <fds-track-files />
+      </rux-tab-panel>
+
       <rux-tab-panel aria-labelledby="data">
         <fds-track-data />
       </rux-tab-panel>
-    </div>
-  </ng-container>
-</fds-tabbed-child-container>
+    </ng-container>
+  </fds-tabbed-child-container>
+</div>

--- a/src/app/main/utility-components/track-data-utility/track-data-utility.component.html
+++ b/src/app/main/utility-components/track-data-utility/track-data-utility.component.html
@@ -1,8 +1,17 @@
-<rux-tabs (click)="tabSelect($event)">
-  <rux-tab id="files" small selected="true">Select Files</rux-tab>
-  <rux-tab id="data" small>Filter/Edit Data</rux-tab>
-</rux-tabs>
-<ng-container [ngSwitch]="selectedTab">
-  <fds-track-files *ngSwitchCase="'files'" />
-  <fds-track-data *ngSwitchCase="'data'" />
-</ng-container>
+<fds-tabbed-child-container
+  [tabs]="tabs"
+  [hasTabPanels]="true"
+  tabsParentId="track-data-tabs"
+  [isUtilityContainer]="true"
+>
+  <ng-container panels>
+    <rux-tab-panel aria-labelledby="files">
+      <fds-track-files />
+    </rux-tab-panel>
+    <div (mousedown)="renderChart()">
+      <rux-tab-panel aria-labelledby="data">
+        <fds-track-data />
+      </rux-tab-panel>
+    </div>
+  </ng-container>
+</fds-tabbed-child-container>

--- a/src/app/main/utility-components/track-data-utility/track-data-utility.component.html
+++ b/src/app/main/utility-components/track-data-utility/track-data-utility.component.html
@@ -1,4 +1,4 @@
-<!-- To ensure the chart renders in Chrome and Safari-->
+<!-- First div to ensure chart renders in safari -->
 <div (mousemove)="renderChart()">
   <fds-tabbed-child-container
     [tabs]="tabs"
@@ -10,10 +10,12 @@
       <rux-tab-panel aria-labelledby="files">
         <fds-track-files />
       </rux-tab-panel>
-
-      <rux-tab-panel aria-labelledby="data">
-        <fds-track-data />
-      </rux-tab-panel>
+      <!-- Second div to make sure it continues to render when you switch tabs in chrome -->
+      <div (mousedown)="renderChart()">
+        <rux-tab-panel aria-labelledby="data">
+          <fds-track-data />
+        </rux-tab-panel>
+      </div>
     </ng-container>
   </fds-tabbed-child-container>
 </div>

--- a/src/app/main/utility-components/track-data-utility/track-data-utility.component.html
+++ b/src/app/main/utility-components/track-data-utility/track-data-utility.component.html
@@ -10,8 +10,8 @@
       <rux-tab-panel aria-labelledby="files">
         <fds-track-files />
       </rux-tab-panel>
-      <!-- Second div to make sure it continues to render when you switch tabs in chrome -->
-      <div (mousedown)="renderChart()">
+      <!-- Second div to ensure it continues to render when you switch tabs in chrome -->
+      <div (mousemove)="renderChart()">
         <rux-tab-panel aria-labelledby="data">
           <fds-track-data />
         </rux-tab-panel>

--- a/src/app/main/utility-components/track-data-utility/track-data-utility.component.ts
+++ b/src/app/main/utility-components/track-data-utility/track-data-utility.component.ts
@@ -15,17 +15,18 @@ import { TabbedChildContainerComponent } from 'src/app/shared';
     AstroComponentsModule,
     TrackFilesComponent,
     TrackDataComponent,
-    TabbedChildContainerComponent
+    TabbedChildContainerComponent,
   ],
   templateUrl: './track-data-utility.component.html',
   styleUrls: ['./track-data-utility.component.css'],
 })
 export class TrackDataUtilityComponent {
-  constructor(private store: Store){}
-  currentSpacecraft$ = this.store.select(selectCurrentSpacecraft)
+  constructor(private store: Store) {}
+  currentSpacecraft$ = this.store.select(selectCurrentSpacecraft);
 
   renderChart() {
-    window.dispatchEvent(new Event('resize')) 
+    const event = new CustomEvent('resize');
+    window.dispatchEvent(event);
   }
 
   tabs: Tabs[] = [

--- a/src/app/main/utility-components/track-data-utility/track-data-utility.component.ts
+++ b/src/app/main/utility-components/track-data-utility/track-data-utility.component.ts
@@ -5,6 +5,8 @@ import { TrackFilesComponent } from 'src/app/main/utility-components/track-data-
 import { TrackDataComponent } from 'src/app/main/utility-components/track-data-utility/track-data/track-data.component';
 import { Store } from '@ngrx/store';
 import { selectCurrentSpacecraft } from 'src/app/+state/app.selectors';
+import { Tabs } from 'src/app/types/Tabs';
+import { TabbedChildContainerComponent } from 'src/app/shared';
 @Component({
   selector: 'fds-track-data-util',
   standalone: true,
@@ -13,19 +15,21 @@ import { selectCurrentSpacecraft } from 'src/app/+state/app.selectors';
     AstroComponentsModule,
     TrackFilesComponent,
     TrackDataComponent,
+    TabbedChildContainerComponent
   ],
   templateUrl: './track-data-utility.component.html',
   styleUrls: ['./track-data-utility.component.css'],
 })
 export class TrackDataUtilityComponent {
-  currentSpacecraft$ = this.store.select(selectCurrentSpacecraft)
-  selectedTab: string = 'files';
-
   constructor(private store: Store){}
+  currentSpacecraft$ = this.store.select(selectCurrentSpacecraft)
 
-  tabSelect(event: any) {
-    if (event.target.id) {
-      this.selectedTab = event.target.id;
-    }
+  renderChart() {
+    window.dispatchEvent(new Event('resize')) 
   }
+
+  tabs: Tabs[] = [
+    { label: 'Select Files', id: 'files', selected: true },
+    { label: 'Filter/Edit Data', id: 'data', selected: false },
+  ];
 }

--- a/src/app/main/utility-components/track-data-utility/track-data/track-data-graph/track-data-graph.component.ts
+++ b/src/app/main/utility-components/track-data-utility/track-data/track-data-graph/track-data-graph.component.ts
@@ -20,8 +20,6 @@ import { TrackFile } from 'src/app/types/data.types';
 import { TrackFilesDataUtilityService } from '../../track-files-data.service';
 import { ChartOptions, getChartOptions, getSeries } from './chart-options';
 
-
-
 type ChartDataItem = {
   az: number;
   el: number;
@@ -49,7 +47,7 @@ export class TrackDataGraphComponent {
   sharedTrackFiles: TrackFile[] = [];
 
   //chart variables
-  chartOptions: ChartOptions = {}
+  chartOptions: ChartOptions = {};
   chartData: ChartDataItem[] = [];
   disableUndo: boolean = true;
 
@@ -63,48 +61,42 @@ export class TrackDataGraphComponent {
   selectedDataPoint: number | null | any = null;
   deletedDataPoints: any[] | null = [];
 
-  seriesIndexName: string = ''
+  seriesIndexName: string = '';
 
   chartEvents = {
     dataPointSelection: (event: any, chartContext: any, config: any) => {
-      const oldPoint = this.selectedDataPoint
-      oldPoint?.classList.remove(
-        'selected-data-point'
-      );
+      const oldPoint = this.selectedDataPoint;
+      oldPoint?.classList.remove('selected-data-point');
 
-      event.target.classList.add(
-          'selected-data-point'
-        );
+      event.target.classList.add('selected-data-point');
 
-      this.selectedDataPoint = event.target
+      this.selectedDataPoint = event.target;
     },
-  }
+  };
   tooltipEvent = {
-  custom: ({ series, seriesIndex, dataPointIndex }: any) => {
-    return (
-      '<div class="tooltip-box">' +
-      '<span> DGS' +
-      '</span> <br/>' +
-      '<span> ' +
-      this.dates[dataPointIndex] +
-      '</span> <br/>' +
-      '<span>' +
-      this.series[seriesIndex].name +
-      ':' +
-      series[seriesIndex][dataPointIndex] +
-      '</span>' +
-      '</div>'
-    );
-  },
-}
+    custom: ({ series, seriesIndex, dataPointIndex }: any) => {
+      return (
+        '<div class="tooltip-box">' +
+        '<span> DGS' +
+        '</span> <br/>' +
+        '<span> ' +
+        this.dates[dataPointIndex] +
+        '</span> <br/>' +
+        '<span>' +
+        this.series[seriesIndex].name +
+        ':' +
+        series[seriesIndex][dataPointIndex] +
+        '</span>' +
+        '</div>'
+      );
+    },
+  };
 
   //subscription cleanup
   destroyRef = inject(DestroyRef);
   destroyed = new Subject();
 
-  constructor(
-    public trackFilesService: TrackFilesDataUtilityService
-  ) {
+  constructor(public trackFilesService: TrackFilesDataUtilityService) {
     this.sharedTrackFiles$
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((res) => {
@@ -121,8 +113,12 @@ export class TrackDataGraphComponent {
   }
 
   ngOnInit() {
-    this.chartOptions = getChartOptions(this.chartEvents, this.tooltipEvent, this.labelsShown)
-    this.series = getSeries()
+    this.chartOptions = getChartOptions(
+      this.chartEvents,
+      this.tooltipEvent,
+      this.labelsShown
+    );
+    this.series = getSeries();
     this.orderByDate(this.sharedTrackFiles);
 
     this.dates = this.sharedTrackFiles.map((file) =>
@@ -176,39 +172,39 @@ export class TrackDataGraphComponent {
     series.visible = !series.visible;
 
     let markers: number[] = [];
-    let dataPoints: number = 0
+    let dataPoints: number = 0;
 
     const updatedSeries = this.series.filter((data: any) => {
-      if (data.visible){ markers.push(data.markerSize);
-        dataPoints = dataPoints + data.data.length
+      if (data.visible) {
+        markers.push(data.markerSize);
+        dataPoints = dataPoints + data.data.length;
       }
       return data.visible;
     });
-    this.dataPointLength = dataPoints
+    this.dataPointLength = dataPoints;
     this.chartComponent?.updateSeries(updatedSeries);
     this.chartComponent?.updateOptions({ markers: { size: [...markers] } });
-
   }
 
   onDelete() {
-    if(!this.selectedDataPoint) return;
-    this.selectedDataPoint.classList.add('hide-node')
-    this.deletedDataPoints?.push(this.selectedDataPoint)
-    if((this.deletedDataPoints as number[]).length >= 1) {
-      this.disableUndo = false
+    if (!this.selectedDataPoint) return;
+    this.selectedDataPoint.classList.add('hide-node');
+    this.deletedDataPoints?.push(this.selectedDataPoint);
+    if ((this.deletedDataPoints as number[]).length >= 1) {
+      this.disableUndo = false;
     }
-    this.dataPointLength = this.dataPointLength - 1
+    this.dataPointLength = this.dataPointLength - 1;
   }
 
   onUndo() {
-    const newUndoArray = this.deletedDataPoints
-    const undoVal = newUndoArray?.pop()
-    undoVal.classList.remove('hide-node')
+    const newUndoArray = this.deletedDataPoints;
+    const undoVal = newUndoArray?.pop();
+    undoVal.classList.remove('hide-node');
     this.deletedDataPoints = newUndoArray;
-    if((this.deletedDataPoints as number[]).length < 1) {
-      this.disableUndo = true
+    if ((this.deletedDataPoints as number[]).length < 1) {
+      this.disableUndo = true;
     }
-    this.dataPointLength = this.dataPointLength + 1
+    this.dataPointLength = this.dataPointLength + 1;
   }
 
   handleZoom(event: any) {

--- a/src/app/main/utility-components/track-data-utility/track-data/track-data.component.ts
+++ b/src/app/main/utility-components/track-data-utility/track-data/track-data.component.ts
@@ -1,9 +1,7 @@
 import { Component, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AstroComponentsModule } from '@astrouxds/angular';
-import {
-  NgApexchartsModule,
-} from 'ng-apexcharts';
+import { NgApexchartsModule } from 'ng-apexcharts';
 import { SitesComponent } from './sites/sites.component';
 import { SettingsComponent } from './settings/settings.component';
 import { TrackDataGraphComponent } from './track-data-graph/track-data-graph.component';
@@ -21,13 +19,13 @@ import { CustomSegmentedButtonComponent } from 'src/app/shared/custom-segmented-
     SettingsComponent,
     TrackDataGraphComponent,
     TrackDataTableComponent,
-    CustomSegmentedButtonComponent
+    CustomSegmentedButtonComponent,
   ],
   templateUrl: './track-data.component.html',
   styleUrls: ['./track-data.component.css'],
 })
 export class TrackDataComponent {
-  @ViewChild('trackDataGraph') trackDataGraph?: TrackDataGraphComponent|null
+  @ViewChild('trackDataGraph') trackDataGraph?: TrackDataGraphComponent | null;
 
   //show/hide variables
   isSitesDrawerOpen: boolean = false;
@@ -41,20 +39,19 @@ export class TrackDataComponent {
 
   toggleSitesDrawer() {
     this.isSitesDrawerOpen = !this.isSitesDrawerOpen;
-    this.trackDataGraph?.toggleChartSize(this.isSitesDrawerOpen)
+    this.trackDataGraph?.toggleChartSize(this.isSitesDrawerOpen);
   }
 
   toggleSettingsDrawer() {
     this.isSettingsDrawerOpen = !this.isSettingsDrawerOpen;
-    this.trackDataGraph?.toggleChartSize(this.isSettingsDrawerOpen)
+    this.trackDataGraph?.toggleChartSize(this.isSettingsDrawerOpen);
   }
 
   viewTable() {
-    this.isSitesDrawerOpen = false
-    this.isSettingsDrawerOpen = false
-    this.leftBtnActive = false
-    this.rightBtnActive = true
-
+    this.isSitesDrawerOpen = false;
+    this.isSettingsDrawerOpen = false;
+    this.leftBtnActive = false;
+    this.rightBtnActive = true;
   }
 
   viewGraph() {

--- a/src/app/main/utility-components/track-data-utility/track-files/track-files.component.css
+++ b/src/app/main/utility-components/track-data-utility/track-files/track-files.component.css
@@ -88,9 +88,14 @@ td:nth-of-type(4) {
   padding-right: 0;
 }
 
+td {
+  cursor: pointer;
+}
+
 th.show-icon {
   padding-right: var(--spacing-6);
 }
+
 tr.selected {
   background-color: var(--color-background-surface-selected);
 }


### PR DESCRIPTION
**JIRA Ticket [Implement Tab Panels in Track-Data](https://rocketcom.atlassian.net/browse/DEMO-429)**

## Brief Description
- Use tabbed-child-component in Track Data Utility
## Issues and/or Limitations
 This was an odd one. I found a [GH Thread](https://github.com/apexcharts/vue-apexcharts/issues/185) where a lot of people had the same issue with the chart not rendering initially. Wrapping the div around the tab panel that contained the `fds-track-data` component worked perfectly- but only in Chrome. Wrapping a second div around the first tab panel causes bugs- so I wrapped a div with a mouseover event around the entire` fds-tabbed-child-container,` and updated the event to `CustomEvent` in the TS, and that solved the issue in Safari. I then tried to remove the div wrapped around the 2nd tab panel (thinking it is no longer necessary), but then then chart wouldn't render while switching between the tabs unless you moved the mouse. SO, having this `renderChart `function called in two places seems to do the trick well. 

## Final Checklist

- [x] Works in Chrome
- [x] Works in Firefox
- [x] Works in Safari
- [x] Handles responsiveness as required
- [x] Dark theme styles are correct
- [x] Light theme styles are correct
